### PR TITLE
feat: Add OpenAI API key as a secret in GitHub Actions workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,7 +31,8 @@ jobs:
           QUARKUS_DB_USERNAME: ${{ secrets.QUARKUS_DB_USERNAME }}
           QUARKUS_DB_PASSWORD: ${{ secrets.QUARKUS_DB_PASSWORD }}
           QUARKUS_DB_URL: ${{ secrets.QUARKUS_DB_URL }}
-          QUARKUS_DB_URL_JDBC: ${{ secrets.QUARKUS_DB_URL_JDBC }}      
+          QUARKUS_DB_URL_JDBC: ${{ secrets.QUARKUS_DB_URL_JDBC }}
+          QUARKUS_OPENAI_API_KEY: ${{ secrets.QUARKUS_OPENAI_API_KEY }}
 
       - name: Build the Docker image
         uses: docker/build-push-action@v4
@@ -47,3 +48,4 @@ jobs:
             QUARKUS_DB_PASSWORD=${{ secrets.QUARKUS_DB_PASSWORD }}
             QUARKUS_DB_URL=${{ secrets.QUARKUS_DB_URL }}
             QUARKUS_DB_URL_JDBC=${{ secrets.QUARKUS_DB_URL_JDBC }}
+            QUARKUS_OPENAI_API_KEY: ${{ secrets.QUARKUS_OPENAI_API_KEY }}


### PR DESCRIPTION
This pull request includes updates to the `.github/workflows/main.yml` file to add a new secret for the OpenAI API key.

* Added `QUARKUS_OPENAI_API_KEY` secret to the environment variables in the `jobs` section. [[1]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R35) [[2]](diffhunk://#diff-7829468e86c1cc5d5133195b5cb48e1ff6c75e3e9203777f6b2e379d9e4882b3R51)