### PR TITLE
feat: Add validation alert for XML download when no filters or search…

### DIFF
--- a/src/main/resources/META-INF/resources/script.js
+++ b/src/main/resources/META-INF/resources/script.js
@@ -89,7 +89,7 @@ $(document).ready(function () {
 
     colors.forEach((color) => {
       let hexCode = colorsHexCode[color];
-      
+
       const colorBox = $("<div>")
         .addClass("w-6 h-6 rounded cursor-pointer")
         .css("background-color", hexCode ?? color.toLowerCase())
@@ -278,6 +278,14 @@ $(document).ready(function () {
           `${encodeURIComponent(key)}=${encodeURIComponent(value)}`
       )
       .join("&");
+
+    if (
+      queryString.indexOf("search") === -1 &&
+      queryString.indexOf("filter") === -1
+    ) {
+      alert("Please apply filters or search to download XML. ");
+      return;
+    }
 
     window.location.href = `/api/cars/xml?${queryString}`;
   }


### PR DESCRIPTION
This pull request includes an important change to the `src/main/resources/META-INF/resources/script.js` file to improve user experience by ensuring that filters or search criteria are applied before allowing the download of XML data.

Enhancements to user experience:

* [`src/main/resources/META-INF/resources/script.js`](diffhunk://#diff-edb5cb8a64d225839581350aaf5b56b45f4ff1660c87480b4352e3bad15501a5R282-R289): Added a check to display an alert if neither search nor filter criteria are present in the query string before initiating the XML download.… are applied