### PR TITLE
fix: Enhance applyFilters function to reset model selection when make…

### DIFF
--- a/src/main/resources/META-INF/resources/script.js
+++ b/src/main/resources/META-INF/resources/script.js
@@ -310,7 +310,14 @@ $(document).ready(function () {
   }
 
   // Apply filters
-  function applyFilters() {
+  function applyFilters(event) {
+
+    const triggerById = event?.target?.id;
+
+    if (triggerById === "make") {
+      $("#model").val("");
+    }
+
     if (isInitFilterParams) return;
     const params = getFilterParams();
     updateURLWithFilter(params);


### PR DESCRIPTION
This pull request includes a change to the `applyFilters` function in `src/main/resources/META-INF/resources/script.js`. The change adds an `event` parameter to the function and includes logic to reset the `model` field if the filter is triggered by the "make" element.

Key changes:

* [`src/main/resources/META-INF/resources/script.js`](diffhunk://#diff-edb5cb8a64d225839581350aaf5b56b45f4ff1660c87480b4352e3bad15501a5L313-R320): Modified the `applyFilters` function to accept an `event` parameter and added logic to reset the `model` field if the filter is triggered by the "make" element.